### PR TITLE
Fix typo in log_in function

### DIFF
--- a/pythorhead/lemmy.py
+++ b/pythorhead/lemmy.py
@@ -20,7 +20,7 @@ class Lemmy:
             re = requests.post(f"{self._api_base_url}/api/v3/user/login", json=payload)
             self._auth_token = re.json()["jwt"]
         except Exception as err:
-            logger.error(f"Something went wrong while logginf in as {username_or_email}: {err}")
+            logger.error(f"Something went wrong while logging in as {username_or_email}: {err}")
             return False
         return True
 


### PR DESCRIPTION
There was a typo within `logger.error` inside the `log_in` function.