### PR TITLE
Update pyproject.toml to specify minimum python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 version = "v0.1.0"
 readme = "README.md"
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.10,<3.11"
 license = { file="LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Project uses PEP 604 type unions which don't exist until 3.10