### PR TITLE
required-python <3.11 --> <3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 version = "v0.9.0"
 readme = "README.md"
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.8,<3.12"
 license = { file="LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Hi,

Could you increase the required max version of python to 3.11?

I've tested it with debian that have python 3.11, and it seems to work.

regards,