### PR TITLE
Remove logging.basicConfig statement

### DIFF
--- a/pythorhead/lemmy.py
+++ b/pythorhead/lemmy.py
@@ -10,8 +10,6 @@ from pythorhead.requestor import Requestor
 from pythorhead.site import Site
 from pythorhead.user import User
 
-logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
 
 class Lemmy:
     _known_communities = {}


### PR DESCRIPTION
This statement causes the application's log level and formatting to be overriden by the Pythörhead import