### PR TITLE
Allow sending of TOTP token with login request

### DIFF
--- a/pythorhead/lemmy.py
+++ b/pythorhead/lemmy.py
@@ -35,8 +35,8 @@ class Lemmy:
     def nodeinfo(self):
         return self._requestor.nodeinfo
 
-    def log_in(self, username_or_email: str, password: str) -> bool:
-        return self._requestor.log_in(username_or_email, password)
+    def log_in(self, username_or_email: str, password: str, totp: Optional[str] = None) -> bool:
+        return self._requestor.log_in(username_or_email, password, totp)
 
     def discover_community(self, community_name: str) -> Optional[int]:
         if community_name in self._known_communities:

--- a/pythorhead/requestor.py
+++ b/pythorhead/requestor.py
@@ -89,10 +89,11 @@ class Requestor:
             return
         return r.json()
 
-    def log_in(self, username_or_email: str, password: str) -> bool:
+    def log_in(self, username_or_email: str, password: str, totp: Optional[str] = None) -> bool:
         payload = {
             "username_or_email": username_or_email,
             "password": password,
+            "totp_2fa_token": totp,
         }
         if data := self.api(Request.POST, "/user/login", json=payload):
             self._auth.set_token(data["jwt"])


### PR DESCRIPTION
Pythorhead doesn't have any facility to send the TOTP code with the login request, so I added it.
I think this is correct, I've not tested it yet.
