### PR TITLE
Return JSON data when image upload fails

### DIFF
--- a/pythorhead/image.py
+++ b/pythorhead/image.py
@@ -56,6 +56,9 @@ class Image:
                 del file["delete_token"]
 
             return data["files"]
+
+        else:
+            return data
         
     def delete(self, image_delete_url: str):
         """

--- a/pythorhead/image.py
+++ b/pythorhead/image.py
@@ -56,9 +56,6 @@ class Image:
                 del file["delete_token"]
 
             return data["files"]
-
-        else:
-            return data
         
     def delete(self, image_delete_url: str):
         """

--- a/pythorhead/requestor.py
+++ b/pythorhead/requestor.py
@@ -121,7 +121,11 @@ class Requestor:
             cookies["jwt"] = self._auth.token
         r = REQUEST_MAP[method](image_delete_url, cookies=cookies, timeout=self.request_timeout, **kwargs)
         if not r.ok:
-            logger.error(f"Error encountered while {method}: {r.text}")
+            if not self.raise_exceptions:
+                logger.error(f"Error encountered while {method}: {r.text}")
+                return
+            else:
+                raise Exception(f"Error encountered while {method}: {r.text}")
             return
         return r
 

--- a/pythorhead/requestor.py
+++ b/pythorhead/requestor.py
@@ -126,7 +126,6 @@ class Requestor:
                 return
             else:
                 raise Exception(f"Error encountered while {method}: {r.text}")
-            return
         return r
 
     def log_in(self, username_or_email: str, password: str, totp: Optional[str] = None) -> bool:


### PR DESCRIPTION
We should return the JSON data from the requests if the image upload fails.

I tried to upload some big images, and got errors such as:

ERROR - Error encountered while Request.POST: {"msg":"Too wide","files":null}

But, there is no way to differenciate errors as if an error occurs, the lemmy.image.upload() will always be None

Also, maybe we should raise an Exception instead ? 

This will break the current image upload exemple :

```python
        try:
            imageUpload = lemmy.image.upload(self.CurrentImage)
        except Exception as e:
            log.warning(e)
        if imageUpload is not None:
...
```

As imageUpload is not None anymore if an error occurs.

This needs a bit of discussion and thinking.

