### PR TITLE
Update mark post as read

### DIFF
--- a/pythorhead/lemmy.py
+++ b/pythorhead/lemmy.py
@@ -41,6 +41,10 @@ class Lemmy:
     def username(self):
         return self._requestor.logged_in_username
 
+    @property
+    def instance_version(self):
+        return self._requestor.get_instance_version()
+    
     def log_in(self, username_or_email: str, password: str, totp: Optional[str] = None) -> bool:
         return self._requestor.log_in(username_or_email, password, totp)
 
@@ -133,3 +137,4 @@ class Lemmy:
 
     def get_base_url(self):
         return self._requestor.domain
+    

--- a/pythorhead/post.py
+++ b/pythorhead/post.py
@@ -328,11 +328,11 @@ class Post:
         Returns:
             Optional[dict]: post data if successful
         """
-        mark_as_read_post = {
+        mark_as_read_posts = {
             "post_ids": post_ids,
             "read": read,
         }
-        return self._requestor.api(Request.POST, "/post/mark_as_read", json=mark_as_read_post)
+        return self._requestor.api(Request.POST, "/post/mark_as_read", json=mark_as_read_posts)
 
     def site_metadata(self, url: str) -> Optional[dict]:
         """

--- a/pythorhead/post.py
+++ b/pythorhead/post.py
@@ -298,7 +298,6 @@ class Post:
             "locked": locked,
         }
         return self._requestor.api(Request.POST, "/post/lock", json=lock_post)
-
     def mark_as_read(self, post_id: int, read: bool) -> Optional[dict]:
         """
 
@@ -311,9 +310,26 @@ class Post:
         Returns:
             Optional[dict]: post data if successful
         """
-
         mark_as_read_post = {
-            "post_id": post_id,
+            "post_ids": [post_id],
+            "read": read,
+        }
+        return self._requestor.api(Request.POST, "/post/mark_as_read", json=mark_as_read_post)
+
+    def mark_multiple_as_read(self, post_ids: list, read: bool) -> Optional[dict]:
+        """
+
+        Mark many posts as read
+
+        Args:
+            post_ids (list)
+            read (bool)
+
+        Returns:
+            Optional[dict]: post data if successful
+        """
+        mark_as_read_post = {
+            "post_ids": post_ids,
             "read": read,
         }
         return self._requestor.api(Request.POST, "/post/mark_as_read", json=mark_as_read_post)

--- a/pythorhead/post.py
+++ b/pythorhead/post.py
@@ -310,10 +310,17 @@ class Post:
         Returns:
             Optional[dict]: post data if successful
         """
-        mark_as_read_post = {
-            "post_ids": [post_id],
-            "read": read,
-        }
+        # < 0.19.4 allows a single post only
+        if self._requestor.get_instance_version().compare("0.19.4") < 0:
+            mark_as_read_post = {
+                "post_id": post_id,
+                "read": read,
+            }
+        else:
+            mark_as_read_post = {
+                "post_ids": [post_id],
+                "read": read,
+            }
         return self._requestor.api(Request.POST, "/post/mark_as_read", json=mark_as_read_post)
 
     def mark_multiple_as_read(self, post_ids: list, read: bool) -> Optional[dict]:


### PR DESCRIPTION
The [API was changed](https://join-lemmy.org/api/interfaces/MarkPostAsRead.html) to accept multiple posts as read, and as such now expect a list of integers, with "post_ids" instead of "post_id".

This updates pythorhead to be able to mark posts read again.

It also adds a second function to take advantage of the new APIs ability to mark multiple posts read with one API call.