### PR TITLE
Add ModeratorView listing type

### DIFF
--- a/pythorhead/types/listing.py
+++ b/pythorhead/types/listing.py
@@ -6,3 +6,4 @@ class ListingType(str, Enum):
     Community = "Community"
     Local = "Local"
     Subscribed = "Subscribed"
+    ModeratorView = "ModeratorView"


### PR DESCRIPTION
This adds the ModeratorView listing type, so lemmy.post.list can display the moderator view which it is currently unable to do.