### PR TITLE
Add community.hide

### DIFF
--- a/pythorhead/community.py
+++ b/pythorhead/community.py
@@ -234,4 +234,25 @@ class Community:
             banFromCommunity["remove_data"] = remove_data
 
         return self._requestor.api(Request.POST, "/community/ban_user", json=banFromCommunity)
+    
+    def hide(
+            self,
+            community_id: int,
+            reason: Optional[str] = None,
+            hidden: bool = False,
+        ) -> Optional[dict]:
+            """
+            Hide a communtiy from public / "All" view (Admin only)
+
+            Args:
+                community ID(int)
+                reason (str, optional): Defaults to None
+                hidden (bool): Defaults to False
+                
+            Returns:
+                Optional[dict]: 
+            """
+            params: dict[str, Any] = {key: value for key, value in locals().items() if value is not None and key != "self"}
+            return self._requestor.api(Request.PUT, "/community/hide", json=params)
+
 


### PR DESCRIPTION
Adds the communtiy.hide functionality from https://join-lemmy.org/api/main#tag/Community/operation/HideCommunity

Tested & working (sets hidden flag = true in the database) on Lemmy 0.19.8