### PR TITLE
add loguru dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "semver >= 3.0.2",
     "pillow >= 10.2.0",
     "python-dateutil >= 2.9.0",
-    "logure => 0.7.3",
+    "loguru => 0.7.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "requests >= 2.31.0, < 3.0.0",
     "semver >= 3.0.2",
     "pillow >= 10.2.0",
-    "python-dateutil >= 2.9.0"
+    "python-dateutil >= 2.9.0",
+    "logure => 0.7.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Hi,

I've got a missed dependency in `loguru` after installing `pythorhead` using pip.

Could it be added to the dependencies section of the `pyproject.toml`?

I think that some change after #6 was addressed must have been lost.

